### PR TITLE
Mic Gain 2 Fix

### DIFF
--- a/rt73.py
+++ b/rt73.py
@@ -333,7 +333,7 @@ button_preset_parameters["P7 ShortPress"] = [ "Bitmask", 0x1386, 0xFF, Button_ID
 mic_gain_parameters = {}
 mic_gain_parameters["Mic gain 1"] = ["Bitmask", 0xA4, 0x80, {0x80: "On", 0x00: "Off"}]
 mic_gain_parameters["Mic gain 1 setting"] = [ "MaskNum", 0xA4, 0x07, lambda x: x*4 , lambda x: int(x/4) ]
-mic_gain_parameters["Mic gain 1"] = ["Bitmask", 0xA5, 0x80, {0x80: "On", 0x00: "Off"}]
+mic_gain_parameters["Mic gain 2"] = ["Bitmask", 0xA5, 0x80, {0x80: "On", 0x00: "Off"}]
 mic_gain_parameters["Mic gain 2 setting"] = [ "MaskNum", 0xA5, 0x1F ]
 
 #DMR settings
@@ -739,7 +739,7 @@ def downloadCodeplug(serialdevice):
         num_pages = response[18]  + response[20]
         print ("Expecting " + str(num_pages) + " pages")
         for i in range(num_pages):
-            print ("Reading page " + str(i))
+            print ("Reading page " + str(i+1))
             port.write("Read".encode('ascii'))
             plug += port.read(2048)
     return plug
@@ -770,6 +770,7 @@ def uploadCodeplug(serialdevice, data):
         if bytes[2:7].decode('ascii') != "Write":
             raise RunTimeException("Unexpected response")
         for i in range(block_count):
+            print ("Writing page " + str(i+1))
             port.write(data[2048*i:2048*(i+1)])
             bytes = port.read(5)
             if bytes.decode('ascii') == "Write":


### PR DESCRIPTION
>"Mic gain 1" is listed twice so "Mic gain 2" is missing from the created JSON file, line 336 should be "Mic gain 2"

>Changed "Reading page" to start from 1 which then ends on the final page. So if expecting 71 pages it ends at 71 rather than 70, maybe less confusing for those that don't expect it to start from 0 and having it look like it's missing the last page. 

>Added "Writing page" to show progress of writing a codeplug, like it does with reading.