### PR TITLE
Added DMR ID 'Ham Contacts' Upload + Fix >64 Contacts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # RT73-utils
 
-This Python script is designed to upload and download codeplugs from the Retevis RT-73 radio (Also known as the Kydera CDR-300UV)
+This Python script is designed to upload and download codeplugs from the Retevis RT73 radio (Also known as the Kydera CDR-300UV)
 
 It can download them, decompile them into a more friendly JSON format, and recompile and reupload them.
+
+It can now upload 'ham contacts' to the radio, slightly quicker than the CPS can.. ~198k contacts in around 40 minutes :)
 
 It can also upgrade the radio's firmware.
 

--- a/compiled_exe/README.md
+++ b/compiled_exe/README.md
@@ -1,2 +1,13 @@
 This is a compiled exe version of the same script.
 This was made using pyinstaller and should contain all dependencies to run the script without the need to manually install Python or PySerial on your own PC/Laptop.
+
+To use this, open a command prompt (cmd.exe) and navigate to the directory where the exe is stored.
+Using the same command arguments as the python version you can download and upload to your radio.
+
+Download/Upload using the default COM port (COM1):
+"rt73.exe download codeplug.json"
+"rt73.exe upload codeplug.json"
+
+Specify your own COM port with the "--device COM*" parameter, e.g COM2:
+"rt73.exe --device COM2 download codeplug.json"
+"rt73.exe --device COM2 upload codeplug.json"

--- a/compiled_exe/README.md
+++ b/compiled_exe/README.md
@@ -1,0 +1,2 @@
+This is a compiled exe version of the same script.
+This was made using pyinstaller and should contain all dependencies to run the script without the need to manually install Python or PySerial on your own PC/Laptop.

--- a/compiled_exe/README.md
+++ b/compiled_exe/README.md
@@ -10,4 +10,19 @@ Download/Upload using the default COM port (COM1):\
 \
 Specify your own COM port with the "--device COM*" parameter, e.g COM2:\
 "rt73.exe --device COM2 download codeplug.json"\
-"rt73.exe --device COM2 upload codeplug.json"
+"rt73.exe --device COM2 upload codeplug.json"\
+\
+\
+DMR ID Database Upload - From CSV File\
+"Ham Contacts" as this radio calls it has been added to the script. It expects the file to be a CSV with headers, specifically the RadioID.net database.\
+"RADIO_ID,CALLSIGN,FIRST_NAME,LAST_NAME,CITY,STATE,COUNTRY"\
+\
+To upload to the radio is as easy as uploading the codeplug, you just need the CSV file location and the contact byte amount you wish to write\
+16 bytes = DMR ID + CALLSIGN ONLY\
+128 bytes = DMR ID + CALLSIGN + NAME + CITY + STATE + COUNTRY\
+\
+"rt73.exe --device COM2 upload_dmrid users.csv --dmridtype 16 (or 128)"\
+\
+\
+The latest World-Wide full database dump is available here, Updated Daily!\
+https://www.radioid.net/static/user.csv

--- a/compiled_exe/README.md
+++ b/compiled_exe/README.md
@@ -1,13 +1,13 @@
-This is a compiled exe version of the same script.
-This was made using pyinstaller and should contain all dependencies to run the script without the need to manually install Python or PySerial on your own PC/Laptop.
-
-To use this, open a command prompt (cmd.exe) and navigate to the directory where the exe is stored.
-Using the same command arguments as the python version you can download and upload to your radio.
-
-Download/Upload using the default COM port (COM1):
-"rt73.exe download codeplug.json"
-"rt73.exe upload codeplug.json"
-
-Specify your own COM port with the "--device COM*" parameter, e.g COM2:
-"rt73.exe --device COM2 download codeplug.json"
+This is a compiled exe version of the same script.\
+This was made using pyinstaller and should contain all dependencies to run the script without the need to manually install Python or PySerial on your own PC/Laptop.\
+\
+To use this, open a command prompt (cmd.exe) and navigate to the directory where the exe is stored.\
+Using the same command arguments as the python version you can download and upload to your radio.\
+\
+Download/Upload using the default COM port (COM1):\
+"rt73.exe download codeplug.json"\
+"rt73.exe upload codeplug.json"\
+\
+Specify your own COM port with the "--device COM*" parameter, e.g COM2:\
+"rt73.exe --device COM2 download codeplug.json"\
 "rt73.exe --device COM2 upload codeplug.json"

--- a/rt73.py
+++ b/rt73.py
@@ -944,24 +944,20 @@ def uploadHamContacts(serialdevice, csvfile, contactbytes):
             else:
                 CONTACT_INFO.append(row['CALLSIGN']+","+row['FIRST_NAME']+","+row['CITY']+","+row['STATE']+","+row['COUNTRY'])
     
-    contact_bytes = contactbytes
     contactcount = len(RADIO_ID)
-    contact_bin_size = contact_bytes * contactcount
-    template = bytearray(b"\x00" * contact_bytes)
+    template = bytearray(b"\x00" * contactbytes)
 
     for i in range(len(RADIO_ID)):
-        template[contact_bytes*i:contact_bytes*i+2] = RADIO_ID[i].to_bytes(length=3, byteorder='little')
-        template[contact_bytes*i+3:] = CONTACT_INFO[i].encode('ascii', 'ignore')
+        template[contactbytes*i:contactbytes*i+2] = RADIO_ID[i].to_bytes(length=3, byteorder='little')
+        template[contactbytes*i+3:] = CONTACT_INFO[i].encode('ascii', 'ignore')
 
-        size = len(template[contact_bytes*i:contact_bytes*i+contact_bytes])
-        if size % contact_bytes != 0:
-            template[contact_bytes*i:contact_bytes*i+contact_bytes] += (b"\x00" * (contact_bytes - (size%contact_bytes)))
+        size = len(template[contactbytes*i:contactbytes*i+contactbytes])
+        if size % contactbytes != 0:
+            template[contactbytes*i:contactbytes*i+contactbytes] += (b"\x00" * (contactbytes - (size%contactbytes)))
             
     if len(template) % 2048 != 0:
-        template[len(template):contact_bin_size] = (b"\x00" * (2048 - (len(template)%2048)))
+        template[len(template):] = (b"\x00" * (2048 - (len(template)%2048)))
 
-    f = open('128', 'wb')
-    f.write(template)
     print("Uploading " + str(contactcount) + " Contacts (" + str(contactbytes) + "bytes)")
 
     block_count = int (len(template) / 2048)
@@ -1002,7 +998,7 @@ def uploadHamContacts(serialdevice, csvfile, contactbytes):
             bytes = port.read(5)
             if bytes[0:6].decode('ascii') == "Write":
                 pass
-            elif bytes[0:6].decode('ascii') == "Check":# and i == block_count-1:
+            elif bytes[0:6].decode('ascii') == "Check":
                 print("Upload Complete...")
             else:
                 print("Unexpected Response From Radio")

--- a/rt73.py
+++ b/rt73.py
@@ -8,7 +8,6 @@ as well as to upgrade the firmware (as supplied by the manufacturer)
 The main purpose is to allow you to enjoy your radio without the need for manufacturer-produced, 
 buggy, windows-only software.
 
-It does not *YET* allow the Ham Contact/Ham Groups upload/download functionality, though I hope to add this soon.
 Encryption settings are (intentionally) not supported, as these are not permitted for amateur radio use.
 
 Any feedback welcome!
@@ -34,12 +33,14 @@ __email__ =  "davidmpye@gmail.com"
 __license__ = "GPLv3"
 __maintainer__ = "David Pye"
 __status__ = "Beta"
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
+__contributions__ = "Dave MM7DBT - DMR ID Database Upload Added :)"
 
 import struct
 import sys
 from enum import Enum
+import csv
 import json
 import serial
 import argparse
@@ -47,6 +48,16 @@ import platform
 import math
 import ctypes
 ctypes.windll.kernel32.SetConsoleTitleW("Retevis RT73 Codeplug/Firmware Tool by David M0DMP")
+
+######################
+######Exit Code Status
+######Code 0 - Success
+######Code 1 - No response from radio (can't connect)
+######Code 2 - Unknown response from radio
+######Code 3 - Codeplug too large >255 pages
+######Code 4 - Codeplug size was incorrect when compiled
+######Code 5 - Firmware Failed - Possibly still updated succesfully though
+#####################
 
 #Record sizes (bytes)
 channel_record_size = 32 
@@ -831,7 +842,7 @@ def compileCodeplug(data):
     if len(template) != codeplug_size:
         print("Codeplug size has been altered - this is a bug")
         print("Should be " + str(codeplug_size) + ", was " + len(template))
-        exit(1)
+        sys.exit(4)
 
     return template
 
@@ -840,32 +851,33 @@ def downloadCodeplug(serialdevice):
     with serial.Serial(serialdevice) as port:
         port.baudrate = 115200
         port.timeout = 10
-        print ("Establishing Connection To Radio...")
+        print("Establishing Connection To Radio...")
         
         if (port.isOpen() == False):
             port.Open()
+            
         port.write("Flash Read ".encode('ascii'))
         port.write(b"\x00\x3c\x00\x00\x00\x00\x00\x39\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
         response = port.read(103)
         if len(response) <= 1:
-            print ("Timeout: Empty Response...")
+            print("Timeout: No Response...")
             sys.exit(1)
         else:
-            print ("Success: Begin Download...")
+            print("Success: Begin Download...")
             
         if debug_level == 4:
             print("Message rx from plug download handshake:")
             print(response)
             for i in range(len(response)):
-                print (hex(response[i]) + " ",end='')
+                print(hex(response[i]) + " ",end='')
 
         num_pages = response[18]  + response[20]
-        print ("Expecting " + str(num_pages) + " pages")
+        print("Expecting " + str(num_pages) + " Blocks")
         for i in range(num_pages):
-            print ("Reading page " + str(i+1))
+            print("Reading Block " + str(i+1) + " of " + str(num_pages))
             port.write("Read".encode('ascii'))
             plug += port.read(2048)
-    print ("Download Complete...")
+    print("Download Complete...")
     return plug
 
 
@@ -877,9 +889,9 @@ def uploadCodeplug(serialdevice, data):
         data += (b"\x00" * (2048 - (size%2048)))
 
     block_count = int (len(data) / 2048)
-    print ("Uploading " + str(block_count) + " pages")
     if block_count > 0xFF:
-        raise RunTimeException("Codeplug too large")
+        print("Codeplug Too Large!")
+        sys.exit(4)
 
     response = bytearray("Flash Write".encode('ascii')) + b"\x00\x3c\x00\x00\x00\x00\x00\xFF\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     response[18] = block_count
@@ -887,85 +899,168 @@ def uploadCodeplug(serialdevice, data):
     with serial.Serial(serialdevice) as port:
         port.baudrate = 115200
         port.timeout = 10
-        print ("Establishing Connection To Radio...")
+        print("Establishing Connection To Radio...")
+        
+        if (port.isOpen() == False):
+            port.Open()
+            
+        port.write(response)
+        bytes = port.read(93)
+        if len(bytes) <= 1:
+            print("Timeout: No Response...")
+            sys.exit(1)
+        else:
+            print("Success: Begin Upload...")
+        print("Writing " + str(block_count) + " Blocks")
+        
+        if bytes[2:7].decode('ascii') != "Write":
+            print("Unexpected Response From Radio")
+            sys.exit(2)
+        for i in range(block_count):
+            print("Writing Block " + str(i+1) + " of " + str(block_count))
+            port.write(data[2048*i:2048*(i+1)])
+            bytes = port.read(5)
+            if bytes.decode('ascii') == "Write":
+                pass
+            elif i == block_count-1 and bytes.decode('ascii') == "Check":
+                print("Upload Complete...")
+            else:
+                print("Unexpected Response From Radio")
+                sys.exit(2)
+    print("Upload Complete...")                                
+
+
+def uploadHamContacts(serialdevice, csvfile, contactbytes):
+
+    RADIO_ID = []
+    CONTACT_INFO = []
+
+    with open(csvfile, 'r', encoding="ascii", errors="surrogateescape") as csv_file:
+        csv_reader = csv.DictReader(csv_file, delimiter=',')    
+        for row in csv_reader:
+            RADIO_ID.append(int(row['RADIO_ID']))
+            if len(row['LAST_NAME']) > 0 and row['LAST_NAME'] != " ":
+                CONTACT_INFO.append(row['CALLSIGN']+","+row['FIRST_NAME']+" "+row['LAST_NAME']+","+row['CITY']+","+row['STATE']+","+row['COUNTRY'])
+            else:
+                CONTACT_INFO.append(row['CALLSIGN']+","+row['FIRST_NAME']+","+row['CITY']+","+row['STATE']+","+row['COUNTRY'])
+    
+    contact_bytes = contactbytes
+    contactcount = len(RADIO_ID)
+    contact_bin_size = contact_bytes * contactcount
+    template = bytearray(b"\x00" * contact_bytes)
+
+    for i in range(len(RADIO_ID)):
+        template[contact_bytes*i:contact_bytes*i+2] = RADIO_ID[i].to_bytes(length=3, byteorder='little')
+        template[contact_bytes*i+3:] = CONTACT_INFO[i].encode('ascii', 'ignore')
+
+        size = len(template[contact_bytes*i:contact_bytes*i+contact_bytes])
+        if size % contact_bytes != 0:
+            template[contact_bytes*i:contact_bytes*i+contact_bytes] += (b"\x00" * (contact_bytes - (size%contact_bytes)))
+            
+    if len(template) % 2048 != 0:
+        template[len(template):contact_bin_size] = (b"\x00" * (2048 - (len(template)%2048)))
+
+    f = open('128', 'wb')
+    f.write(template)
+    print("Uploading " + str(contactcount) + " Contacts (" + str(contactbytes) + "bytes)")
+
+    block_count = int (len(template) / 2048)
+    #if block_count > 0x30D4:
+    #    raise RunTimeException("DMR Database Too Large") #Need to work out maximum block count - possibly 18750 (300k contacts of 128 bytes)
+    
+    response = b""
+    response += bytearray("Flash Write".encode('ascii')) 
+    response += b'\x81\x10\x00\x00\x00\x00'
+    response += bytearray(block_count.to_bytes(2, 'big')) #block count
+    response += b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x2B'
+    response += bytearray(contactbytes.to_bytes(1, 'little')) # 16 or 128
+    response += b'\x2B\x00'
+    response += bytearray(contactcount.to_bytes(3, 'big')) #contact count
+
+    with serial.Serial(serialdevice) as port:
+        port.baudrate = 115200
+        port.timeout = 10
+        print("Establishing Connection To Radio...")
+        
         if (port.isOpen() == False):
             port.Open()
     
         port.write(response)
         bytes = port.read(93)
         if len(bytes) <= 1:
-            print ("Timeout: Empty Response...")
+            print("Timeout: Empty Response...")
             sys.exit(1)
         else:
-            print ("Success: Begin Upload...")
-        print ("Writing " + str(block_count) + " pages")
-        
+            print("Success: Begin Upload...")
+        print("Writing " + str(block_count) + " Blocks")
         if bytes[2:7].decode('ascii') != "Write":
-            raise RunTimeException("Unexpected response")
+            print("Unexpected Response From Radio")
+            sys.exit(2)
         for i in range(block_count):
-            print ("Writing page " + str(i+1))
-            port.write(data[2048*i:2048*(i+1)])
+            print("Writing Block " + str(i+1) + " of " + str(block_count))
+            port.write(template[2048*i:2048*(i+1)])
             bytes = port.read(5)
-            if bytes.decode('ascii') == "Write":
+            if bytes[0:6].decode('ascii') == "Write":
                 pass
-            elif i == block_count-1 and bytes.decode('ascii') == "Check":
-                print ("Write completed OK")
+            elif bytes[0:6].decode('ascii') == "Check":# and i == block_count-1:
+                print("Upload Complete...")
             else:
-                print(bytes)
-                raise RunTimeError("Unexpected response from radio")
-    print ("Upload Complete...")                                
+                print("Unexpected Response From Radio")
+                sys.exit(2)
+    print("Upload Complete...")      
 
 
 def uploadFirmware(serialdevice, data):
     with serial.Serial(serialdevice) as port:
         port.baudrate = 115200
+        port.timeout = 10
+        
         if (port.isOpen() == False):
             port.Open()
             
-        print ("Starting Firmware Upload Process")
+        print("Starting Firmware Upload Process")
         port.write("Erase".encode('ascii'))
         
         num_blocks = math.ceil(len(data) / 2048)
         
         port.write(b"\x20\x20\x20\x20\x20\x20\x00\x00\x00\x00\x00\x00") # \x01\x87")
         port.write((num_blocks-1).to_bytes(length=2, byteorder='little'))
- 
+        
+        #Should be "Erase ok"
         bytes = port.read(41)
-        #print(bytes)
-        # Last section should be "Erase ok"
-        if bytes[33:].decode('ascii') == "Erase ok":
+        if len(bytes) <= 1:
+            print("Timeout: Empty Response...")
+            sys.exit(1)
+        elif bytes[33:].decode('ascii') == "Erase ok":
             print("Erase OK - Begin Writing")
         else:
-            print (bytes)
-            raise RunTimeException("Erase failed - unexpected response")
+            print("Unexpected Response From Radio")
+            sys.exit(2)
 
         num_blocks = math.ceil(len(data) / 2048)
         
         for i in range(num_blocks):
             block = data[2048*i:2048*(i+1)]
-            print ("Writing Block " +str(i+1) +" of " + str(num_blocks))
+            print("Writing Block " +str(i+1) +" of " + str(num_blocks))
             if i == num_blocks - 1 and len(block) != 2048:
                 # The final block isn't 2048 bytes long, so pad if necessary
-                print ("Added " + str(2048-len(block)) + " pad bytes")
+                print("Added " + str(2048-len(block)) + " pad bytes")
                 block += b"\x00" * (2048-len(block))
-            #Write block to the radio
             port.write(block)
 
             bytes = port.read(3) #Check this says "kyd"
             if bytes.decode('ascii') == "kyd":
-                #print ("OK")
-                kyd = "OK"
+                pass
             else:
-                debugMsg(0, "Unexpected response from radio - " + bytes.decode('ascii'))
-                raise RunTimeException("Unexpected response")
+                print("Unexpected Response From Radio")
+                sys.exit(2)
         bytes = port.read(8)
-        #print(bytes)
         if bytes[0:8].decode('ascii') == "Checksum":
             #Seems it worked, there always seem to be messages about flash errors even with the proper SW :-O
-            print ("Firmware Upload Complete")
+            print("Firmware Upload Complete")
         else:
-            print (bytes)
-            #raise RunTimeException("Unexpected response from radio - " + bytes.decode('ascii'))
+            print("Unexpected Response From Radio - May be normal - Firmware upload is not perfect :)")
+            sys.exit(5)
 
 
 def debugMsg(level, message):
@@ -984,11 +1079,15 @@ elif platform.system() == "Windows":
 parser = argparse.ArgumentParser(
     description = "Retevis RT73 codeplug/firmware upgrade tool, GNU GPL v3 or later, (C) 2020-21 David Pye davidmpye@gmail.com"
 )
-parser.add_argument('action', type = str, choices=["upload", "download", "flash_fw", "download_bin", "upload_bin", "decompile_bin"], help='''upload - Compile and upload a JSON-formatted file to the radio,
-download - Download and convert the radio's codeplug to a JSON-formatted file,
-flash_fw - Upgrade the radio's firmware (radio must be powered on while pressing P1 and be displaying a grey screen before upload)''')
+parser.add_argument('action', type = str, choices=["upload", "download", "flash_fw", "download_bin", "upload_bin", "decompile_bin", "upload_dmrid"], help=
+    "upload - Compile and upload a JSON-formatted file to the radio,\n"+
+    "download - Download and convert the radio's codeplug to a JSON-formatted file,"+
+    "flash_fw - Upgrade the radio's firmware (radio must be powered on while pressing P1 and be displaying a grey screen before upload),"+
+    "upload_dmrid - Upload Ham Contacts to the radio, file must be in RadioID.net CSV format and specify type with --dmridtype {16 or 128}")
+        
 parser.add_argument("filename", type=str, help="Filename to upload, or to save")
 
+parser.add_argument('--dmridtype', type = int, choices=[16,128], help="Ham Contacts Bytes (16 or 128)")
 parser.add_argument('--device', default = default_serial_device, help = "Specify device to use (default COM1 on Windows, default /dev/ttyUSB0 on Linux")
 parser.add_argument('--debuglevel', default=[0], type = int, nargs = 1, help="Debug level (0 = default, 4 = max)")
 args = parser.parse_args()
@@ -1006,8 +1105,6 @@ elif args.action == "upload":
     input = f.read()
     data = compileCodeplug(input)
     f.close()
-    #ff = open("temp.bin", 'wb')
-    #ff.write(data)
     uploadCodeplug(args.device, data)
 elif args.action == "flash_fw":
     f = open(args.filename,'rb')
@@ -1027,3 +1124,5 @@ elif args.action == "decompile_bin":
     f.close()
     ff = open(args.filename[:-4]+".json", 'w')
     ff.write(data)
+elif args.action == "upload_dmrid":
+    uploadHamContacts(args.device, args.filename, args.dmridtype)

--- a/rt73.py
+++ b/rt73.py
@@ -45,6 +45,8 @@ import serial
 import argparse
 import platform
 import math
+import ctypes
+ctypes.windll.kernel32.SetConsoleTitleW("Retevis RT73 Codeplug/Firmware Tool by David M0DMP")
 
 #Record sizes (bytes)
 channel_record_size = 32 
@@ -85,12 +87,12 @@ CTCSS_Tones = [ 62.5, 67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5, 85.4, 88.5, 91.5
 
 #List of the DCS tones used - the CPS UI displays an N (normal) or I (Inverted) at the end, depending on whether normal or inverted mode is selected.
 DCS_Codes = [
-    "017", "023", "025", "026", "031", "032", "036", "043", "047", "050", "051", "053", "054", "065", "071", "072", "073", "074", "114", 
-    "115", "116", "122", "125", "131", "132", "134", "143", "145", "152", "155", "156", "162", "165", "172", "174", "205", "212", "223", 
-    "225", "226", "243", "244", "245", "246", "251", "252", "255", "261", "263", "265", "266", "271", "274", "306", "311", "315", "325", 
-    "331", "332", "343", "346", "351", "356", "364", "365", "371", "411", "412", "413", "423", "431", "432", "445", "446", "452", "454", 
-    "455", "462", "464", "465", "466", "503", "506", "516", "523", "526", "532", "546", "565", "606", "612", "624", "627", "631", "632", 
-    "645", "646", "654", "662", "664", "703", "712", "723", "731", "732", "734", "743", "754" ]
+    17, 23, 25, 26, 31, 32, 36, 43, 47, 50, 51, 53, 54, 65, 71, 72, 73, 74, 114, 
+    115, 116, 122, 125, 131, 132, 134, 143, 145, 152, 155, 156, 162, 165, 172, 174, 205, 212, 223, 
+    225, 226, 243, 244, 245, 246, 251, 252, 255, 261, 263, 265, 266, 271, 274, 306, 311, 315, 325, 
+    331, 332, 343, 346, 351, 356, 364, 365, 371, 411, 412, 413, 423, 431, 432, 445, 446, 452, 454, 
+    455, 462, 464, 465, 466, 503, 506, 516, 523, 526, 532, 546, 565, 606, 612, 624, 627, 631, 632, 
+    645, 646, 654, 662, 664, 703, 712, 723, 731, 732, 734, 743, 754 ]
 
 Button_IDs = {
     0x00: "UNDEFINED",
@@ -206,7 +208,7 @@ basic_parameters["Squelch B level"]  =  [ "MaskNum", 0x93, 0xF0, lambda x:x>>4, 
 basic_parameters["Backlight"] = [ "Bitmask", 0x95, 0x28, {0x00: "Off", 0x08: "On", 0x20: "Auto" }]
 basic_parameters["Keylock"] = [ "Bitmask", 0x95, 0x44, {0x00: "Off", 0x04: "Auto", 0x40: "Manual", 0x44: "Manual & Auto" }]
 basic_parameters["Roaming"] = [ "Bitmask", 0x137B, 0x01, {0x00: "Off", 0x01: "On"}]
-basic_parameters["Roaming mode"] = [ "Bitmask", 0x1375, 0x03, {0x00: "Auto", 0x01: "Manual", 0x03: "Strong RSSI Priority"}]
+basic_parameters["Roaming mode"] = [ "Bitmask", 0x1375, 0x03, {0x00: "Auto", 0x01: "Manual", 0x02: "Strong RSSI Priority"}]
 basic_parameters["RSSI set"] = [ "MaskNum", 0x1376, 0xFF, lambda x: -90 - x , lambda x: -1*x - 90 ]
 basic_parameters["Connect check timer"] =  [ "MaskNum", 0x1377, 0xFF ]
 basic_parameters["Repeater check timer"] =  [ "MaskNum", 0x1378, 0xFF ]
@@ -240,6 +242,7 @@ common_menu_parameters["Call log missed"] = [ "Bitmask", 0xB0, 0x04, {0x00: "Off
 common_menu_parameters["Scan on/off"] = [ "Bitmask", 0xB1, 0x01, {0x00: "Off", 0x01: "On"}]
 common_menu_parameters["Scan list"] = [ "Bitmask", 0xB1, 0x02, {0x00: "Off", 0x02: "On"}]
 common_menu_parameters["Scan mode"] = [ "Bitmask", 0xB1, 0x04, {0x00: "Off", 0x04: "On"}]
+common_menu_parameters["Roam on/off"] = [ "Bitmask", 0xB1, 0x08, {0x00: "Off", 0x08: "On"}]
 common_menu_parameters["Scan running on/off"] = [ "Bitmask", 0x10, 0x10, {0x00: "Off", 0x10: "On"}]
 
 common_menu_parameters["Zone list on/off"] = [ "Bitmask", 0xB2, 0x01, {0x00: "Off", 0x01: "On"}]
@@ -285,6 +288,11 @@ common_menu_parameters["Time"] = [ "Bitmask", 0xB7, 0x08, {0x00: "Off", 0x08: "O
 common_menu_parameters["DTMF"] = [ "Bitmask", 0xB7, 0x10, {0x00: "Off", 0x10: "On"}]
 common_menu_parameters["Speaker handmic"] = [ "Bitmask", 0xB7, 0x20, {0x00: "Off", 0x20: "On"}]
 
+common_menu_parameters["Record set"] = [ "Bitmask", 0xB8, 0x01, {0x00: "Off", 0x01: "On"}]
+common_menu_parameters["Record list"] = [ "Bitmask", 0xB8, 0x02, {0x00: "Off", 0x02: "On"}]
+common_menu_parameters["Record clear"] = [ "Bitmask", 0xB8, 0x04, {0x00: "Off", 0x04: "On"}]
+common_menu_parameters["Record space"] = [ "Bitmask", 0xB8, 0x08, {0x00: "Off", 0x08: "On"}]
+
 common_menu_parameters["Radio ID"] = [ "Bitmask", 0xB9, 0x01, {0x00: "Off", 0x01: "On"}]
 common_menu_parameters["RX group list"] = [ "Bitmask", 0xB9, 0x02, {0x00: "Off", 0x02: "On"}]
 common_menu_parameters["Channel contact"] = [ "Bitmask", 0xB9, 0x04, {0x00: "Off", 0x04: "On"}]
@@ -302,7 +310,7 @@ prompt_tone_parameters["Key tone"] = [ "Bitmask", 0xAB, 0x80, {0x00: "Off", 0x80
 prompt_tone_parameters["Key tone vol"] = [ "MaskNum", 0xAB, 0x0F ]
 prompt_tone_parameters["Low bat alert tone"] = [ "Bitmask", 0xAC, 0x80, {0x00: "Off", 0x80: "On"}]
 prompt_tone_parameters["Low bat alert vol"] = [ "MaskNum", 0xAC, 0x0F ]
-prompt_tone_parameters["Call hang up"] =  [ "Bitmask", 0x12d8, 0x01, {0x00: "Silent", 0x01: "Prompt tone"}]
+prompt_tone_parameters["Call hang up"] =  [ "Bitmask", 0x12d8, 0x01, {0x00: "Silent", 0x01: "Prompt Tone"}]
 prompt_tone_parameters["Boot ringtone"] = [ "Bitmask", 0x95, 0x02, {0x00: "Off", 0x02: "On"}]
 prompt_tone_parameters["Roaming restart prompt"] = [ "MaskNum", 0x1383, 0x0F ]
 prompt_tone_parameters["Repeater selected prompt"] = [ "MaskNum", 0x1383, 0x0F ]
@@ -417,14 +425,14 @@ contact_parameters = {}
 contact_parameters["ID"] = [ "Number", 0x00, 2 ]
 contact_parameters["Name"] = [ "String", 0x03, 10 ]
 contact_parameters["DMR ID"] = [ "Number", 0x0D, 3 ]
-contact_parameters["Type"] = ["Bitmask", 0x02, 0xFF, {0x04: "Group", 0x05: "Private", 0x06: "All call", 0x07: "No-address call", 0x08: "RawData", 0x09: "Define Data", 0x0A: "SPDATA"}]
+contact_parameters["Type"] = ["Bitmask", 0x02, 0xFF, {0x04: "Group", 0x05: "Private", 0x06: "All Call", 0x07: "No-Address Call", 0x08: "RawData", 0x09: "Define Data", 0x0A: "SPDATA"}]
 
 # Scan list
 scan_list_info = {}
 # NB These are relative to the scan list record bytes, not the whole codeplug.
 scan_list_info["Name"] = [ "String", 0x00, 10] 
 scan_list_info["Talkback"] = [ "Bitmask", 0x0B, 0x20, { 0x00: "Off", 0x20: "On" } ]
-scan_list_info["Scan TX Mode"] = [ "Bitmask", 0x0B, 0x0F, { 0x00: "Current channel", 0x04: "Last operated channel", 0x08:  "Appointed channel" } ]
+scan_list_info["Scan TX Mode"] = [ "Bitmask", 0x0B, 0x0F, { 0x00: "Current Channel", 0x04: "Last Operated Channel", 0x08:  "Appointed Channel" } ]
 scan_list_info["Appointed channel group ID"] = [ "Number", 0x0C, 2]
 scan_list_info["Appointed channel channel ID"] = [ "Number", 0x0E, 2 ]
 
@@ -445,19 +453,19 @@ channel_info = {}
 # NB These are relative to the zone record bytes, not the whole codeplug.
 #Structure: Human readable name: Type,  byte offset, length (mask if bitmask), ( enum values if bitmask)
 channel_info["ID"] =  ["Number", 0x00, 2  ]
-channel_info[ "Type"] = ["Bitmask", 0x14, 0xC0, { 0x00: "ANALOG",  0x40: "DIGITAL",  0x80: "D_A_TX_A",  0xC0: "D_A_TX_D" } ]
-channel_info[ "Name"] =  ["String", 0x02, 10 ]
-channel_info[ "Rx Freq"] =  ["Number", 0x0C, 4  ]
-channel_info[ "Tx Freq"] = ["Number", 0x10, 4  ]
-channel_info[ "Tx Power"] =  [ "Bitmask", 0x14, 0x20, { 0x00: "LOW", 0x20: "HIGH" }]
+channel_info["Type"] = ["Bitmask", 0x14, 0xC0, { 0x00: "ANALOG",  0x40: "DIGITAL",  0x80: "D_A_TX_A",  0xC0: "D_A_TX_D" } ]
+channel_info["Name"] =  ["String", 0x02, 10 ]
+channel_info["Rx Freq"] =  ["Number", 0x0C, 4  ]
+channel_info["Tx Freq"] = ["Number", 0x10, 4  ]
+channel_info["Tx Power"] =  [ "Bitmask", 0x14, 0x20, { 0x00: "LOW", 0x20: "HIGH" }]
 channel_info["Rx only"] = [ "Bitmask", 0x19, 0x10, { 0x00: "OFF", 0x10: "ON" }]
 channel_info["Alarm"]= [ "Bitmask", 0x14, 0x08, { 0x00: "OFF", 0x08: "ON" }]
-channel_info[ "Prompt"] = [ "Bitmask", 0x14, 0x08 , { 0x00: "OFF", 0x08: "ON" } ]
-channel_info[ "PCT"] = [ "Bitmask", 0x14, 0x02, { 0x00: "PATCS", 0x02: "OACSU" }]
-channel_info[ "TS Rx"]=  [ "Bitmask", 0x14, 0x01, { 0x00: "TS1", 0x01: "TS2" } ]
+channel_info["Prompt"] = [ "Bitmask", 0x14, 0x08 , { 0x00: "OFF", 0x08: "ON" } ]
+channel_info["PCT"] = [ "Bitmask", 0x14, 0x02, { 0x00: "PATCS", 0x02: "OACSU" }]
+channel_info["TS Rx"]=  [ "Bitmask", 0x14, 0x01, { 0x00: "TS1", 0x01: "TS2" } ]
 channel_info["TS Tx"] =[ "Bitmask", 0x1D, 0x02, { 0x00: "TS1", 0x02: "TS2" } ]
-channel_info[ "RX CC"] = ["MaskNum", 0x15, 0x0F]
-channel_info[ "TX CC"] = ["MaskNum", 0x1D, 0xF0, lambda x: x>>4, lambda x: x<<4]
+channel_info["RX CC"] = ["MaskNum", 0x15, 0x0F]
+channel_info["TX CC"] = ["MaskNum", 0x1D, 0xF0, lambda x: x>>4, lambda x: x<<4]
 channel_info["MSG Type"] =  [ "Bitmask", 0x15, 0x10, { 0x00: "UNCONFIRMED", 0x10: "CONFIRMED" }]
 channel_info["TX Policy"] =  [ "Bitmask", 0x15, 0xC0, { 0x00: "IMPOLITE", 0x40: "POLITE_TO_CC", 0x60: "POLITE_TO_ALL" }]
 channel_info["Group call list"] =  ["Number", 0x17, 1]
@@ -469,9 +477,9 @@ channel_info["Default Contact ID"] =  ["Number", 0x1E, 1]
 channel_info["EAS"] =   [ "Bitmask", 0x19, 0x0F, { 0x00: "OFF", 0x01: "A1", 0x02: "A2", 0x03: "A3", 0x04: "A4" }]
 channel_info["Bandwidth"] =  [ "Bitmask", 0x14, 0x10, { 0x10: "25KHz", 0x00: "12.5KHz" } ]
 # CTCSS/DCS details
-channel_info["Tone Type Tx"] = [ "Bitmask", 0x1A, 0x0C, { 0x00: "None", 0x04: "CTCSS", 0x08: "DCS", 0x0C: "DCS Invert" }]
+channel_info["Tone Type Tx"] = [ "Bitmask", 0x1A, 0x0C, { 0x00: "OFF", 0x04: "CTCSS", 0x08: "DCS", 0x0C: "DCS Invert" }]
 channel_info["Tone Tx"] = [ "Number",0x1C, 1 ]
-channel_info["Tone Type Rx"] = [ "Bitmask", 0x1A, 0x03, { 0x00: "None", 0x01: "CTCSS", 0x02: "DCS", 0x03: "DCS Invert" }]
+channel_info["Tone Type Rx"] = [ "Bitmask", 0x1A, 0x03, { 0x00: "OFF", 0x01: "CTCSS", 0x02: "DCS", 0x03: "DCS Invert" }]
 channel_info["Tone Rx"] = [ "Number",0x1B, 1 ]
 # APRS setting
 channel_info["APRS Channel" ] = [ "MaskNum", 0x1F, 0xF0, lambda x: x>>4, lambda x: x<<4 ]
@@ -623,13 +631,13 @@ def decompileCodeplug(data):
             #TX tones
             if channel["Tone Type Tx"] == "CTCSS":
                 channel["Tone Tx"] = CTCSS_Tones[channel["Tone Tx"]]
-            elif channel["Tone Type Tx"] != "None": # It's DCS or DCS Invert
+            elif channel["Tone Type Tx"] != "OFF": # It's DCS or DCS Invert
                 channel["Tone Tx"] = DCS_Codes[channel["Tone Tx"]]
 
             #RX tones
             if channel["Tone Type Rx"] == "CTCSS":
                 channel["Tone Rx"] = CTCSS_Tones[channel["Tone Rx"]]
-            elif channel["Tone Type Rx"] != "None": # It's DCS or DCS Invert
+            elif channel["Tone Type Rx"] != "OFF": # It's DCS or DCS Invert
                 channel["Tone Rx"] = DCS_Codes[channel["Tone Rx"]]
 
             parsed_zone["Channels"].append(channel)
@@ -638,7 +646,7 @@ def decompileCodeplug(data):
         codeplug["Zones"].append(parsed_zone)
 
     #Jsonify it, and return it
-    return json.dumps(codeplug, indent=4)
+    return json.dumps(codeplug, indent=2)
 
 
 def compileCodeplug(data):
@@ -779,12 +787,12 @@ def compileCodeplug(data):
             #Need to turn the CTCSS/DCS code values back into the enumerated constant.
             if channel["Tone Type Tx"] == "CTCSS":
                 channel["Tone Tx"] = CTCSS_Tones.index(channel["Tone Tx"])
-            elif channel["Tone Type Tx"] != "None": # It's DCS or DCS Invert
+            elif channel["Tone Type Tx"] != "OFF": # It's DCS or DCS Invert
                 channel["Tone Tx"] = DCS_Codes.index(channel["Tone Tx"])
             #RX tones
             if channel["Tone Type Rx"] == "CTCSS":
                 channel["Tone Rx"] = CTCSS_Tones.index(channel["Tone Rx"])
-            elif channel["Tone Type Rx"] != "None": # It's DCS or DCS Invert
+            elif channel["Tone Type Rx"] != "OFF": # It's DCS or DCS Invert
                 channel["Tone Rx"] = DCS_Codes.index(channel["Tone Rx"])
             
             channel_record = bytearray(channel_record_size)
@@ -793,10 +801,10 @@ def compileCodeplug(data):
             template[channel_start_address + (channel_record_size * count) : channel_start_address + (channel_record_size * (count + 1))] = channel_record
             count = count + 1
 
-    if len(template) != codeplug_size:
-        print("Codeplug size has been altered - this is a bug")
-        print("Should be " + str(codeplug_size) + ", was " + len(template))
-        exit(1)
+    #if len(template) != codeplug_size:
+        #print("Codeplug size has been altered - this is a bug")
+        #print("Should be " + str(codeplug_size) + ", was " + len(template))
+        #exit(1)
 
     return template
 
@@ -804,12 +812,20 @@ def downloadCodeplug(serialdevice):
     plug = bytearray()
     with serial.Serial(serialdevice) as port:
         port.baudrate = 115200
+        port.timeout = 10
+        print ("Establishing Connection To Radio...")
+        
         if (port.isOpen() == False):
             port.Open()
         port.write("Flash Read ".encode('ascii'))
         port.write(b"\x00\x3c\x00\x00\x00\x00\x00\x39\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
         response = port.read(103)
-        
+        if len(response) <= 1:
+            print ("Timeout: Empty Response...")
+            sys.exit(1)
+        else:
+            print ("Success: Begin Download...")
+            
         if debug_level == 4:
             print("Message rx from plug download handshake:")
             print(response)
@@ -822,6 +838,7 @@ def downloadCodeplug(serialdevice):
             print ("Reading page " + str(i+1))
             port.write("Read".encode('ascii'))
             plug += port.read(2048)
+    print ("Download Complete...")
     return plug
 
 
@@ -842,11 +859,20 @@ def uploadCodeplug(serialdevice, data):
 
     with serial.Serial(serialdevice) as port:
         port.baudrate = 115200
+        port.timeout = 10
+        print ("Establishing Connection To Radio...")
         if (port.isOpen() == False):
             port.Open()
     
         port.write(response)
         bytes = port.read(93)
+        if len(bytes) <= 1:
+            print ("Timeout: Empty Response...")
+            sys.exit(1)
+        else:
+            print ("Success: Begin Upload...")
+        print ("Uploading " + str(block_count) + " pages")
+        
         if bytes[2:7].decode('ascii') != "Write":
             raise RunTimeException("Unexpected response")
         for i in range(block_count):
@@ -860,6 +886,7 @@ def uploadCodeplug(serialdevice, data):
             else:
                 print(bytes)
                 raise RunTimeError("Unexpected response from radio")
+    print ("Upload Complete...")                                
 
 
 def uploadFirmware(serialdevice, data):
@@ -867,7 +894,8 @@ def uploadFirmware(serialdevice, data):
         port.baudrate = 115200
         if (port.isOpen() == False):
             port.Open()
-        print ("Starting firmware flashing process")        
+            
+        print ("Starting firmware flashing process")
         port.write("Erase".encode('ascii'))
         
         num_blocks = math.ceil(len(data) / 2048)


### PR DESCRIPTION
Hi David,

I've done some work with the script over the past week or so and thought I'd create this pull request, if you wanted to merge into your own.

Major changes;
- Addition of uploading the ham contacts via CSV file. Based on the database dump files from RadioID.net but could easily be adapted to suit other column headers.
- Hopefully fixed the >64 contact issue, It seems the CPS (at least the versions I tried) like to create an odd number of total contact blocks. Likely why it was fine up to 64 and then break until 128 and work again as it was on an odd block count.

Minor changes;
- Just some clean-up of print messages, changes to capitalization etc.. Mainly aimed towards my use in my editor, look a little better and less confusing for those that get worried about weird things on their screen; print(bytes) haha

I assume the Ham Groups are written in a similar way, so it'd probably be straight forward to add that in at a later date, Not actually sure what the ham groups actually do lol
Firmware flashing doesn't work as people expect it to, likely because the radio seems to return an error, even after flashing is successful.. So the radio doesn't turn off automatically like it does when updating using the IAP software.




Thanks,
Dave