### PR TITLE
Add Ham Groups, Fix Timeslot "ON"

### DIFF
--- a/rt73.py
+++ b/rt73.py
@@ -220,7 +220,7 @@ basic_parameters["Radio name"] = [ "String", 0x80, 10]
 basic_parameters["DMR ID"] = [ "Number", 0x90, 3]
 
 basic_parameters["Language"] = [ "Bitmask", 0x95, 0x10, {0x00: "Chinese", 0x10: "English"}]
-basic_parameters["TimeoutTimer"] = [ "MaskNum", 0x134F, 0x32, lambda x: x*10, lambda x: int(x/10) ]  
+basic_parameters["TimeoutTimer"] = [ "Number", 0x134F, 1]
 basic_parameters["Busy channel lockout"] = [ "Bitmask", 0xA6, 0x80, {0x00: "Off", 0x80: "On"}]
 basic_parameters["VOX"] = [ "Bitmask", 0xA6, 0x40, {0x00: "Off", 0x40: "On"}]
 basic_parameters["VOX sensitivity"] = [ "MaskNum", 0xA6, 0x0F, lambda x:x+1, lambda x: x-1]

--- a/rt73.py
+++ b/rt73.py
@@ -220,6 +220,7 @@ basic_parameters["Radio name"] = [ "String", 0x80, 10]
 basic_parameters["DMR ID"] = [ "Number", 0x90, 3]
 
 basic_parameters["Language"] = [ "Bitmask", 0x95, 0x10, {0x00: "Chinese", 0x10: "English"}]
+basic_parameters["TimeoutTimer"] = [ "MaskNum", 0x134F, 0x32, lambda x: x*10, lambda x: int(x/10) ]  
 basic_parameters["Busy channel lockout"] = [ "Bitmask", 0xA6, 0x80, {0x00: "Off", 0x80: "On"}]
 basic_parameters["VOX"] = [ "Bitmask", 0xA6, 0x40, {0x00: "Off", 0x40: "On"}]
 basic_parameters["VOX sensitivity"] = [ "MaskNum", 0xA6, 0x0F, lambda x:x+1, lambda x: x-1]


### PR DESCRIPTION
Hi David,

Me again haha, I have added Ham Groups and put in a fix for a small issue regarding the timeslots (TS1, TS2, ON)

There are 2 bits that are set high or low when selecting ON for the Tx or Rx timeslot. As it happens they are set to 0 when ON is selected so because the bits aren't set within the script they are always being set to 0 which caused a small issue of the original CPS reading every channel as having the timeslot to ON.
Although it shouldn't actually be possible to set it to ON unless the Tx and Rx Frequency is the same, i.e Simplex so you would have to go through every channel in the CPS manually to get it to update to the correct timeslot in order for it to update the binary value, which it does as soon as you highlight the channel but still needs to be done manually for every channel.

<img src="https://www.rt73editor.com/img/rt73-tson.png" alt="before-after" width="800"/>

I'm not sure what effect this has on the actual radio as I've not had any issues using it through repeaters and a simplex hotspot, but the values in memory are still technically incorrect so this should set them correctly now.

I added a float definition to the To/FromBytes code, Last night I was looking into how the Fixed Location Beacon is being set but I didn't get anywhere.. other than reading the float value from the 4 bytes, which in my quick test was a small exponent like 1.27^-27 which I haven't quite worked out how to get from that to the actual degrees value.

Another work in progress, not that I believe fixed location is that important. It's just nice to have it all working.

Cheers once again :)
Dave